### PR TITLE
Source/Minor: Account for values close to integer

### DIFF
--- a/interface.js
+++ b/interface.js
@@ -959,10 +959,19 @@ function displayProgress(prefix, progress, total, received) {
 function humanReadableFormOf(bytes) {
     const BYTE_SCALING = 1024;
     const units        = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const MAX_CONV = 1024 ** (units.length - 1);
+    const EPSILON = 1e-6;
+    assert(bytes <= MAX_CONV);
+
     let   i;
     for (i = 0; bytes >= BYTE_SCALING && i < units.length - 1; i++) {
         bytes /= BYTE_SCALING;
     }
+
+    // If we are close to an integer print the integer without a `.00` suffix
+    if(bytes - Math.floor(bytes) <= EPSILON)
+        return `${bytes}${units[i]}`;
+
     return `${bytes.toFixed(2)}${units[i]}`;
 }
 
@@ -3180,6 +3189,7 @@ export function exports() {
             checkIfActuallyRoot,
             findIndexFile,
             downloadProject,
+            humanReadableFormOf,
             bundleProject,
             removeTemplates,
             finalizeWriter,

--- a/test/readability.test.js
+++ b/test/readability.test.js
@@ -1,0 +1,13 @@
+import {cv, expect, path, PROJECT_NAME} from './test_setup.js';
+
+describe(`${PROJECT_NAME}::humanReadable`, () => {
+    it('should give a human readable format for raw bytes', () => {
+        expect(cv.humanReadableFormOf(1000)).to.equal('1000B');
+        expect(cv.humanReadableFormOf(1024 ** 4)).to.equal('1TB');
+        try {
+            cv.humanReadableFormOf(1024 * 5);
+        } catch (err) {
+            expect(err.code).to.equal('ERR_ASSERTION');
+        }
+    });
+});


### PR DESCRIPTION
In function humanReadableFormOf, it returns an
human formatted form of a given byte. If the
value provided is close to an integer, a `.00`
suffix is appended by the .toFixed() function.
We check for values close to this an epsilon
threshold and return the integer form.
